### PR TITLE
Improve the effiency of edit-fasta-according-to-new-cprops

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This post-processing includes four steps: (i) a polishing algorithm which attemp
 - `GNU coreutils sort >=8.11`
 - `Python >=2.7` -  for chromosome number-aware splitter module only 
 - `scipy numpy matplotlib` - for chromosome number-aware splitter module only
+- `BioPython` - for edit fasta
+- `seqkit` - for wrapping sequence
 
 #### Recommended
 - `GNU Parallel >=20150322` – highly recommended to increase performance

--- a/edit/edit-fasta-according-to-new-cprops.py
+++ b/edit/edit-fasta-according-to-new-cprops.py
@@ -2,7 +2,7 @@
 import sys
 import re
 import argparse
-import fileinput
+from Bio import SeqIO
 
 parser = argparse.ArgumentParser()
 #parser.add_argument("--label1", help="fraglabel")
@@ -15,17 +15,7 @@ args = parser.parse_args()
 crop_file = args.crop_file
 fasta_file = args.fasta_file
 
-
-# parse fasta
-record_dict = {}
-with open(fasta_file, "r") as handle:
-    for line in handle:
-        if line.startswith('>'):
-            seq_name = line.strip().split()[0][1:]
-            tmpseq = record_dict.get(seq_name, [])
-        else:
-            tmpseq.append(line.strip())
-            record_dict[seq_name] = tmpseq
+record_dict = SeqIO.to_dict(SeqIO.parse(fasta_file, "fasta"))
 
 fasta_id_list = []
 # record the position of contigs
@@ -40,10 +30,10 @@ for line in open(crop_file, "r"):
         continue
 
     if len(items) == 3:
-        
+
         fasta_id_list.append(contig_id)
 
-        seq = record_dict[contig_id]
+        seq = str(record_dict[contig_id].seq)
         print(">{}\n{}".format(contig_id, seq))
     else:
 
@@ -52,7 +42,7 @@ for line in open(crop_file, "r"):
             fasta_id_list.append(contig_id)
             seq_start = 0
             seq_end = seq_start + contig_len
-            seq = record_dict[contig_id][seq_start:seq_end]
+            seq = str(record_dict[contig_id].seq)[seq_start:seq_end]
             if len(items) == 4:
                 print(">{}:::{}\n{}".format(contig_id, items[1], seq))
             else:
@@ -61,11 +51,8 @@ for line in open(crop_file, "r"):
             seq_start = 0 + sum(pos_dict[contig_id])
             seq_end = seq_start + contig_len
             pos_dict[contig_id].append(contig_len)
-            seq = record_dict[contig_id][seq_start:seq_end]
+            seq = str(record_dict[contig_id].seq)[seq_start:seq_end]
             if len(items) == 4:
                 print(">{}:::{}\n{}".format(contig_id, items[1], seq))
             else:
                 print(">{}:::{}:::{}\n{}".format(contig_id, items[1], items[2], seq))
-
-        
-

--- a/edit/edit-fasta-according-to-new-cprops.py
+++ b/edit/edit-fasta-according-to-new-cprops.py
@@ -30,10 +30,10 @@ for line in open(crop_file, "r"):
         items = []
         if all_items[2] == "debris":
             items.append(all_items[0] + ":::" + all_items[1] + ":::" + all_items[2])
-            items.append(all_items[2:])
+            items = items + all_items[2:]
         else:
             items.append(all_items[0] + ":::" + all_items[1])
-            items.append(all_items[1:])
+            items = items + all_items[1:]
 
     contig_id = items[0]
     contig_len = int(items[-1])

--- a/edit/edit-fasta-according-to-new-cprops.py
+++ b/edit/edit-fasta-according-to-new-cprops.py
@@ -1,0 +1,51 @@
+import sys
+import re
+from Bio import SeqIO
+
+crop_file = sys.argv[1]
+fasta_file = sys.argv[2]
+
+record_dict = SeqIO.to_dict(SeqIO.parse(fasta_file, "fasta"))
+
+fasta_id_list = []
+# record the position of contigs
+pos_dict = {}
+
+for line in open(crop_file, "r"):
+    items = re.split(":::|\s",line.strip())
+    contig_id = items[0]
+    contig_len = int(items[-1])
+
+    if contig_id not in record_dict:
+        continue
+
+    if len(items) == 3:
+        
+        fasta_id_list.append(contig_id)
+
+        seq = str(record_dict[contig_id].seq)
+        print(">{}\n{}".format(contig_id, seq))
+    else:
+
+        if contig_id not in fasta_id_list:
+            pos_dict[contig_id] = [contig_len]
+            fasta_id_list.append(contig_id)
+            seq_start = 0
+            seq_end = seq_start + contig_len
+            seq = str(record_dict[contig_id].seq)[seq_start:seq_end]
+            if len(items) == 4:
+                print(">{}:::{}\n{}".format(contig_id, items[1], seq))
+            else:
+                print(">{}:::{}:::{}\n{}".format(contig_id, items[1], items[2], seq))
+        else:
+            seq_start = 0 + sum(pos_dict[contig_id])
+            seq_end = seq_start + contig_len
+            pos_dict[contig_id].append(contig_len)
+            seq = str(record_dict[contig_id].seq)[seq_start:seq_end]
+            if len(items) == 4:
+                print(">{}:::{}\n{}".format(contig_id, items[1], seq))
+            else:
+                print(">{}:::{}:::{}\n{}".format(contig_id, items[1], items[2], seq))
+
+        
+

--- a/edit/edit-fasta-according-to-new-cprops.py
+++ b/edit/edit-fasta-according-to-new-cprops.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python
 import sys
 import re
+import argparse
+import fileinput
 
-crop_file = sys.argv[1]
-fasta_file = sys.argv[2]
+parser = argparse.ArgumentParser()
+#parser.add_argument("--label1", help="fraglabel")
+#parser.add_argument("--label2", help="annolabel")
+parser.add_argument("crop_file", help="cprops file")
+parser.add_argument("fasta_file", help="fasta file")
+
+args = parser.parse_args()
+
+crop_file = args.crop_file
+fasta_file = args.fasta_file
+
 
 # parse fasta
 record_dict = {}
@@ -33,7 +44,6 @@ for line in open(crop_file, "r"):
         fasta_id_list.append(contig_id)
 
         seq = record_dict[contig_id]
-        print seq
         print(">{}\n{}".format(contig_id, seq))
     else:
 

--- a/edit/edit-fasta-according-to-new-cprops.py
+++ b/edit/edit-fasta-according-to-new-cprops.py
@@ -5,8 +5,8 @@ import argparse
 from Bio import SeqIO
 
 parser = argparse.ArgumentParser()
-#parser.add_argument("--label1", help="fraglabel")
-#parser.add_argument("--label2", help="annolabel")
+parser.add_argument("--label", help="fraglabel, fragment or overhang", default="fragment")
+#parser.add_argument("--label2", help="annolabel debris or gap", default = "debris")
 parser.add_argument("crop_file", help="cprops file")
 parser.add_argument("fasta_file", help="fasta file")
 
@@ -14,6 +14,7 @@ args = parser.parse_args()
 
 crop_file = args.crop_file
 fasta_file = args.fasta_file
+label = args.label
 
 record_dict = SeqIO.to_dict(SeqIO.parse(fasta_file, "fasta"))
 
@@ -22,7 +23,18 @@ fasta_id_list = []
 pos_dict = {}
 
 for line in open(crop_file, "r"):
-    items = re.split(":::|\s",line.strip())
+    all_items = re.split(":::|\s",line.strip())
+    if label == "fragment":
+        items = all_items
+    else:
+        items = []
+        if all_items[2] == "debris":
+            items.append(all_items[0] + ":::" + all_items[1] + ":::" + all_items[2])
+            items.append(all_items[2:])
+        else:
+            items.append(all_items[0] + ":::" + all_items[1])
+            items.append(all_items[1:])
+
     contig_id = items[0]
     contig_len = int(items[-1])
 

--- a/edit/edit-fasta-according-to-new-cprops.py
+++ b/edit/edit-fasta-according-to-new-cprops.py
@@ -1,11 +1,20 @@
+#!/usr/bin/env python
 import sys
 import re
-from Bio import SeqIO
 
 crop_file = sys.argv[1]
 fasta_file = sys.argv[2]
 
-record_dict = SeqIO.to_dict(SeqIO.parse(fasta_file, "fasta"))
+# parse fasta
+record_dict = {}
+with open(fasta_file, "r") as handle:
+    for line in handle:
+        if line.startswith('>'):
+            seq_name = line.strip().split()[0][1:]
+            tmpseq = record_dict.get(seq_name, [])
+        else:
+            tmpseq.append(line.strip())
+            record_dict[seq_name] = tmpseq
 
 fasta_id_list = []
 # record the position of contigs
@@ -23,7 +32,8 @@ for line in open(crop_file, "r"):
         
         fasta_id_list.append(contig_id)
 
-        seq = str(record_dict[contig_id].seq)
+        seq = record_dict[contig_id]
+        print seq
         print(">{}\n{}".format(contig_id, seq))
     else:
 
@@ -32,7 +42,7 @@ for line in open(crop_file, "r"):
             fasta_id_list.append(contig_id)
             seq_start = 0
             seq_end = seq_start + contig_len
-            seq = str(record_dict[contig_id].seq)[seq_start:seq_end]
+            seq = record_dict[contig_id][seq_start:seq_end]
             if len(items) == 4:
                 print(">{}:::{}\n{}".format(contig_id, items[1], seq))
             else:
@@ -41,7 +51,7 @@ for line in open(crop_file, "r"):
             seq_start = 0 + sum(pos_dict[contig_id])
             seq_end = seq_start + contig_len
             pos_dict[contig_id].append(contig_len)
-            seq = str(record_dict[contig_id].seq)[seq_start:seq_end]
+            seq = record_dict[contig_id][seq_start:seq_end]
             if len(items) == 4:
                 print(">{}:::{}\n{}".format(contig_id, items[1], seq))
             else:

--- a/finalize/remove-N-overhangs-from-asm.sh
+++ b/finalize/remove-N-overhangs-from-asm.sh
@@ -44,20 +44,26 @@ pipeline=`cd "$( dirname $0)" && cd .. && pwd`
 make_gap_bed=${pipeline}/utils/make-gap-bed.awk
 edit_cprops=${pipeline}/edit/edit-cprops-according-to-annotations.awk
 edit_asm=${pipeline}/edit/edit-asm-according-to-new-cprops.sh
-edit_fasta=${pipeline}/edit/edit-fasta-according-to-new-cprops.awk
+#edit_fasta=${pipeline}/edit/edit-fasta-according-to-new-cprops.awk
+edit_fasta=${pipeline}/edit/edit-fasta-according-to-new-cprops.py
 
 prefix=`basename ${orig_cprops} .cprops`
 
-awk -f ${make_gap_bed} ${orig_fasta} | awk 'BEGIN{OFS="\t"; print "chr1", "x1", "x2", "chr2", "y1", "y2","color", "id", "X1", "X2", "Y1", "Y2"}FILENAME==ARGV[1]{len[$1]=$3;next}$2==0{print $1, $2, $3, $1, $2, $3, "0,0,0", "gap", $2, $3, $2, $3; next}$3==len[$1]{print $1, $2, $3, $1, $2, $3, "0,0,0", "gap", $2, $3, $2, $3}' ${orig_cprops} - | awk -v label1=":::overhang_" -v label2=":::gap" -f ${edit_cprops} - ${orig_cprops} > ${prefix}.no_overhangs.cprops
+awk -f ${make_gap_bed} ${orig_fasta} | \
+	awk 'BEGIN{OFS="\t"; print "chr1", "x1", "x2", "chr2", "y1", "y2","color", "id", "X1", "X2", "Y1", "Y2"}FILENAME==ARGV[1]{len[$1]=$3;next}$2==0{print $1, $2, $3, $1, $2, $3, "0,0,0", "gap", $2, $3, $2, $3; next}$3==len[$1]{print $1, $2, $3, $1, $2, $3, "0,0,0", "gap", $2, $3, $2, $3}' ${orig_cprops} - | \
+	awk -v label1=":::overhang_" -v label2=":::gap" -f ${edit_cprops} - ${orig_cprops} > ${prefix}.no_overhangs.cprops
 
 new_cprops=${prefix}.no_overhangs.cprops
 
 prefix=`basename ${orig_asm} .asm`
 
-bash ${edit_asm} ${new_cprops} ${orig_cprops} ${orig_asm} | awk 'FILENAME==ARGV[1]{if($1~/:::gap/){skip[$2]=1; skip[-$2]=1}; next}{str=""; for(i=1;i<=NF;i++){if(! skip[$i]){str=str" "$i}}; if(str!=""){print substr(str,2)}}' ${new_cprops} - > ${prefix}.no_overhangs.asm
+bash ${edit_asm} ${new_cprops} ${orig_cprops} ${orig_asm} | \
+	awk 'FILENAME==ARGV[1]{if($1~/:::gap/){skip[$2]=1; skip[-$2]=1}; next}{str=""; for(i=1;i<=NF;i++){if(! skip[$i]){str=str" "$i}}; if(str!=""){print substr(str,2)}}' ${new_cprops} - > ${prefix}.no_overhangs.asm
 
 prefix=`basename ${orig_fasta} .fa`
 prefix=`basename ${prefix} .fna`
 prefix=`basename ${prefix} .fasta`
 
-awk -v label1=":::overhang_" -v label2=":::gap" -f ${edit_fasta} ${new_cprops} ${orig_fasta} | awk '$0~/>/{test=1; if($0~/:::gap/){test=0}}test{print}' > ${prefix}.no_overhangs.fasta
+#awk -v label1=":::overhang_" -v label2=":::gap" -f ${edit_fasta} ${new_cprops} ${orig_fasta} | awk '$0~/>/{test=1; if($0~/:::gap/){test=0}}test{print}' > ${prefix}.no_overhangs.fasta
+python3 ${edit_fasta} ${new_cprops} ${orig_fasta} | awk '$0~/>/{test=1; if($0~/:::gap/){test=0}}test{print}' > ${prefix}.no_overhangs.fasta
+

--- a/finalize/remove-N-overhangs-from-asm.sh
+++ b/finalize/remove-N-overhangs-from-asm.sh
@@ -65,5 +65,5 @@ prefix=`basename ${prefix} .fna`
 prefix=`basename ${prefix} .fasta`
 
 #awk -v label1=":::overhang_" -v label2=":::gap" -f ${edit_fasta} ${new_cprops} ${orig_fasta} | awk '$0~/>/{test=1; if($0~/:::gap/){test=0}}test{print}' > ${prefix}.no_overhangs.fasta
-python3 ${edit_fasta} ${new_cprops} ${orig_fasta} | awk '$0~/>/{test=1; if($0~/:::gap/){test=0}}test{print}' > ${prefix}.no_overhangs.fasta
+python3  ${edit_fasta} --label overhang ${new_cprops} ${orig_fasta} | awk '$0~/>/{test=1; if($0~/:::gap/){test=0}}test{print}' > ${prefix}.no_overhangs.fasta
 

--- a/finalize/remove-N-overhangs-from-asm.sh
+++ b/finalize/remove-N-overhangs-from-asm.sh
@@ -65,5 +65,5 @@ prefix=`basename ${prefix} .fna`
 prefix=`basename ${prefix} .fasta`
 
 #awk -v label1=":::overhang_" -v label2=":::gap" -f ${edit_fasta} ${new_cprops} ${orig_fasta} | awk '$0~/>/{test=1; if($0~/:::gap/){test=0}}test{print}' > ${prefix}.no_overhangs.fasta
-python3  ${edit_fasta} --label overhang ${new_cprops} ${orig_fasta} | awk '$0~/>/{test=1; if($0~/:::gap/){test=0}}test{print}' > ${prefix}.no_overhangs.fasta
+python3  ${edit_fasta} --label overhang ${new_cprops} ${orig_fasta} | seqkit seq -w 80 | awk '$0~/>/{test=1; if($0~/:::gap/){test=0}}test{print}' > ${prefix}.no_overhangs.fasta
 

--- a/run-asm-pipeline-post-review.sh
+++ b/run-asm-pipeline-post-review.sh
@@ -248,7 +248,7 @@ else
 
 	# build final fasta
 	#awk -f ${pipeline}/edit/edit-fasta-according-to-new-cprops.awk ${genomeid}.final.cprops ${orig_fasta} > ${genomeid}.final.fasta
-        python3 ${pipeline}/edit/edit-fasta-according-to-new-cprops.py ${genomeid}.final.cprops ${orig_fasta}  > ${genomeid}.final.fasta
+    python3 ${pipeline}/edit/edit-fasta-according-to-new-cprops.py ${genomeid}.final.cprops ${orig_fasta}  > ${genomeid}.final.fasta
  
 	bash ${pipeline}/finalize/finalize-output.sh -s ${input_size} -l ${genomeid} -g ${gap_size} ${genomeid}.final.cprops ${genomeid}.final.asm ${genomeid}.final.fasta final
 

--- a/run-asm-pipeline-post-review.sh
+++ b/run-asm-pipeline-post-review.sh
@@ -248,7 +248,7 @@ else
 
 	# build final fasta
 	#awk -f ${pipeline}/edit/edit-fasta-according-to-new-cprops.awk ${genomeid}.final.cprops ${orig_fasta} > ${genomeid}.final.fasta
-    python3 ${pipeline}/edit/edit-fasta-according-to-new-cprops.py ${genomeid}.final.cprops ${orig_fasta}  > ${genomeid}.final.fasta
+    python3 ${pipeline}/edit/edit-fasta-according-to-new-cprops.py ${genomeid}.final.cprops ${orig_fasta} | seqkit seq -w 80 > ${genomeid}.final.fasta
  
 	bash ${pipeline}/finalize/finalize-output.sh -s ${input_size} -l ${genomeid} -g ${gap_size} ${genomeid}.final.cprops ${genomeid}.final.asm ${genomeid}.final.fasta final
 

--- a/run-asm-pipeline-post-review.sh
+++ b/run-asm-pipeline-post-review.sh
@@ -247,7 +247,9 @@ else
 	rm ${genomeid}.final.mnd.txt
 
 	# build final fasta
-	awk -f ${pipeline}/edit/edit-fasta-according-to-new-cprops.awk ${genomeid}.final.cprops ${orig_fasta} > ${genomeid}.final.fasta
+	#awk -f ${pipeline}/edit/edit-fasta-according-to-new-cprops.awk ${genomeid}.final.cprops ${orig_fasta} > ${genomeid}.final.fasta
+        python3 ${pipeline}/edit/edit-fasta-according-to-new-cprops.py ${genomeid}.final.cprops ${orig_fasta}  > ${genomeid}.final.fasta
+ 
 	bash ${pipeline}/finalize/finalize-output.sh -s ${input_size} -l ${genomeid} -g ${gap_size} ${genomeid}.final.cprops ${genomeid}.final.asm ${genomeid}.final.fasta final
 
 	# if requested build HiC map with added gaps

--- a/run-asm-pipeline.sh
+++ b/run-asm-pipeline.sh
@@ -827,7 +827,8 @@ if [ "$stage" != "merge" ] && [ "$stage" != "finalize" ]; then
 	rm ${genomeid}.rawchrom.mnd.txt
 
 	# prep for merging and finalizing
-	awk -f ${pipeline}/edit/edit-fasta-according-to-new-cprops.awk ${genomeid}.rawchrom.cprops ${orig_fasta} > ${genomeid}.rawchrom.fasta
+	#awk -f ${pipeline}/edit/edit-fasta-according-to-new-cprops.awk ${genomeid}.rawchrom.cprops ${orig_fasta} > ${genomeid}.rawchrom.fasta
+	python3 ${pipeline}/edit/edit-fasta-according-to-new-cprops.py ${genomeid}.final.cprops ${orig_fasta} > ${genomeid}.final.fasta
 	
 	if [ $diploid == "false" ]; then
 		ln -sf ${genomeid}.rawchrom.cprops ${genomeid}.final.cprops

--- a/run-asm-pipeline.sh
+++ b/run-asm-pipeline.sh
@@ -828,7 +828,7 @@ if [ "$stage" != "merge" ] && [ "$stage" != "finalize" ]; then
 
 	# prep for merging and finalizing
 	#awk -f ${pipeline}/edit/edit-fasta-according-to-new-cprops.awk ${genomeid}.rawchrom.cprops ${orig_fasta} > ${genomeid}.rawchrom.fasta
-	python3 ${pipeline}/edit/edit-fasta-according-to-new-cprops.py ${genomeid}.final.cprops ${orig_fasta} > ${genomeid}.final.fasta
+	python3 ${pipeline}/edit/edit-fasta-according-to-new-cprops.py ${genomeid}.final.cprops ${orig_fasta} | seqkit seq -w 80 > ${genomeid}.final.fasta
 	
 	if [ $diploid == "false" ]; then
 		ln -sf ${genomeid}.rawchrom.cprops ${genomeid}.final.cprops


### PR DESCRIPTION
I write a `edit-fasta-according-to-new-cprops.py` which do the same thing as `edit-fasta-according-to-new-cprops.awk` and generate the same results.

 I have  used `cmp` to compare the results of edit-fasta-according-to-new-cprops.py and edit-fasta-according-to-new-cprops.awk .The results of `cmp` show no difference between.

I also test it in my own project, it works well, no error throws out.

The seqkit seq -m 80 is used to wrap the fasta which is more effient than using python text.wrap.